### PR TITLE
Revamp skills section layout

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6833,6 +6833,100 @@ footer {
   padding: 20px;
   text-align: left; }
 
+.skill-card {
+  background: linear-gradient(135deg, #0b1d33 0%, #0f3057 50%, #1f4b99 100%);
+  border-radius: 14px;
+  padding: 35px 32px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.18);
+  color: #e9f1ff;
+  position: relative;
+  overflow: hidden; }
+  .skill-card:before {
+    content: '';
+    position: absolute;
+    top: -60px;
+    right: -120px;
+    width: 280px;
+    height: 280px;
+    background: radial-gradient(circle at center, rgba(255, 255, 255, 0.15), transparent 60%);
+    transform: rotate(25deg); }
+  .skill-card__header {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 15px;
+    margin-bottom: 25px;
+    position: relative;
+    z-index: 1; }
+    .skill-card__header p {
+      margin: 0;
+      color: rgba(233, 241, 255, 0.8); }
+  .skill-card__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+    gap: 18px;
+    position: relative;
+    z-index: 1; }
+
+.skill-category {
+  display: flex;
+  gap: 14px;
+  padding: 16px 18px;
+  border-radius: 12px;
+  background: rgba(255, 255, 255, 0.04);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.08);
+  transition: transform 0.25s ease, box-shadow 0.25s ease, border-color 0.25s ease; }
+  .skill-category:hover {
+    transform: translateY(-3px);
+    border-color: rgba(255, 255, 255, 0.18);
+    box-shadow: 0 12px 26px rgba(0, 0, 0, 0.2); }
+  .skill-category__icon {
+    width: 40px;
+    height: 40px;
+    border-radius: 10px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.12);
+    color: #fff;
+    font-size: 16px;
+    flex-shrink: 0; }
+  .skill-category__content h6 {
+    margin: 0 0 8px;
+    color: #ffffff;
+    letter-spacing: 0.2px;
+    font-weight: 600; }
+
+.skill-chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px; }
+
+.skill-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 40px;
+  background: rgba(255, 255, 255, 0.1);
+  color: #f5f8ff;
+  font-size: 12px;
+  letter-spacing: 0.3px;
+  border: 1px solid rgba(255, 255, 255, 0.16);
+  transition: background 0.2s ease, border-color 0.2s ease; }
+  .skill-chip:hover {
+    background: rgba(255, 255, 255, 0.18);
+    border-color: rgba(255, 255, 255, 0.3); }
+
+@media (max-width: 767px) {
+  .skill-card {
+    padding: 28px 22px; }
+  .skill-card__header {
+    flex-direction: column;
+    align-items: flex-start; }
+  .skill-category {
+    padding: 14px 15px; } }
+
 .skillbar {
   position: relative;
   display: block;

--- a/index.html
+++ b/index.html
@@ -146,53 +146,94 @@
 
 					<br>
 					<br>
-					<!-- skill-section -->
-							<div id="skills" class="active-section">
-	<div class="section-block skill-section">
-		<div class="row">
-			<div class="col-md-6">
-				<div class="skill-content">
-					<h4 class="title">Skills</h4>
+                                        <!-- skill-section -->
+                                                        <div id="skills" class="active-section">
+        <div class="section-block skill-section">
+                <div class="row">
+                        <div class="col-md-12">
+                                <div class="skill-card">
+                                        <div class="skill-card__header">
+                                                <h4 class="title">Skills</h4>
+                                                <p>Modern engineering toolkit across mobile, backend, DevOps, and product delivery.</p>
+                                        </div>
+                                        <div class="skill-card__grid">
+                                                <div class="skill-category">
+                                                        <div class="skill-category__icon"><i class="fa fa-code"></i></div>
+                                                        <div class="skill-category__content">
+                                                                <h6>Core Languages &amp; Frameworks</h6>
+                                                                <div class="skill-chip-list">
+                                                                        <span class="skill-chip">C#</span>
+                                                                        <span class="skill-chip">.NET Core</span>
+                                                                        <span class="skill-chip">.NET MAUI</span>
+                                                                        <span class="skill-chip">Xamarin</span>
+                                                                        <span class="skill-chip">Blazor</span>
+                                                                        <span class="skill-chip">Razor</span>
+                                                                        <span class="skill-chip">MVVM</span>
+                                                                </div>
+                                                        </div>
+                                                </div>
 
-					<h6>Android Studio</h6>
-					<div class="skillbar clearfix " data-percent="90%">
-						<div class="skillbar-bar" style="width: 10%;"></div>
-						<div class="skill-bar-percent">90%</div>
-					</div> <!-- End Skill Bar -->
+                                                <div class="skill-category">
+                                                        <div class="skill-category__icon"><i class="fa fa-mobile"></i></div>
+                                                        <div class="skill-category__content">
+                                                                <h6>Mobile Development</h6>
+                                                                <div class="skill-chip-list">
+                                                                        <span class="skill-chip">Android</span>
+                                                                        <span class="skill-chip">iOS</span>
+                                                                        <span class="skill-chip">Cross-platform</span>
+                                                                        <span class="skill-chip">Xamarin</span>
+                                                                        <span class="skill-chip">.NET MAUI</span>
+                                                                </div>
+                                                        </div>
+                                                </div>
 
-					<h6>Visual Studio</h6>
-					<div class="skillbar clearfix " data-percent="90%">
-						<div class="skillbar-bar" style="width: 50%;"></div>
-						<div class="skill-bar-percent">90%</div>
-					</div> <!-- End Skill Bar -->
+                                                <div class="skill-category">
+                                                        <div class="skill-category__icon"><i class="fa fa-server"></i></div>
+                                                        <div class="skill-category__content">
+                                                                <h6>Backend &amp; APIs</h6>
+                                                                <div class="skill-chip-list">
+                                                                        <span class="skill-chip">RESTful APIs</span>
+                                                                        <span class="skill-chip">Entity Framework</span>
+                                                                        <span class="skill-chip">Firebase</span>
+                                                                        <span class="skill-chip">OpenAPI Documentation</span>
+                                                                </div>
+                                                        </div>
+                                                </div>
 
-					
+                                                <div class="skill-category">
+                                                        <div class="skill-category__icon"><i class="fa fa-lock"></i></div>
+                                                        <div class="skill-category__content">
+                                                                <h6>DevOps &amp; Security</h6>
+                                                                <div class="skill-chip-list">
+                                                                        <span class="skill-chip">GitLab</span>
+                                                                        <span class="skill-chip">CI/CD</span>
+                                                                        <span class="skill-chip">Automated Pipelines</span>
+                                                                        <span class="skill-chip">Keycloak</span>
+                                                                        <span class="skill-chip">OAuth2</span>
+                                                                        <span class="skill-chip">OIDC</span>
+                                                                </div>
+                                                        </div>
+                                                </div>
 
-					<h6>Pycharm</h6>
-					<div class="skillbar clearfix " data-percent="75%">
-						<div class="skillbar-bar" style="width: 50%;"></div>
-						<div class="skill-bar-percent">75%</div>
-					</div> <!-- End Skill Bar -->
-
-					<h6>Unity</h6>
-					<div class="skillbar clearfix " data-percent="70%">
-						<div class="skillbar-bar" style="width: 30%;"></div>
-						<div class="skill-bar-percent">70%</div>
-					</div> <!-- End Skill Bar -->
-
-					<h6>Photoshop</h6>
-					<div class="skillbar clearfix " data-percent="75%">
-						<div class="skillbar-bar" style="width: 35%;"></div>
-						<div class="skill-bar-percent">75%</div>
-					</div> <!-- End Skill Bar -->
-				</div>
-			</div>
-			<div class="col-md-6">
-				<img class="img-responsive" src="https://i.imgur.com/ASzCBFJ.png" alt="">
-			</div>
-		</div>
-	</div>
-	</div>
+                                                <div class="skill-category">
+                                                        <div class="skill-category__icon"><i class="fa fa-database"></i></div>
+                                                        <div class="skill-category__content">
+                                                                <h6>Databases &amp; Tools</h6>
+                                                                <div class="skill-chip-list">
+                                                                        <span class="skill-chip">MySQL</span>
+                                                                        <span class="skill-chip">PostgreSQL</span>
+                                                                        <span class="skill-chip">Agile</span>
+                                                                        <span class="skill-chip">Scrum</span>
+                                                                        <span class="skill-chip">Jira</span>
+                                                                </div>
+                                                        </div>
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </div>
+        </div>
 					<br>
 					<br>
 


### PR DESCRIPTION
## Summary
- replace skill progress bars with structured categories and chips that reflect requested content
- add new gradient skill card styling with hover effects and responsive layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692ee444f6108325bec1ab1d0efba56d)