### PR TITLE
Simplify skills layout into stacked rows

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6833,6 +6833,89 @@ footer {
   padding: 20px;
   text-align: left; }
 
+
+.skill-card {
+  background: #ffffff;
+  border-radius: 12px;
+  padding: 32px 28px;
+  box-shadow: 0 8px 22px rgba(0, 0, 0, 0.06);
+  border: 1px solid #e6e9ed;
+  color: #2c2c2c;
+  position: relative;
+  overflow: hidden; }
+  .skill-card__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 15px;
+    margin-bottom: 18px;
+    position: relative;
+    z-index: 1; }
+    .skill-card__header h4.title {
+      margin: 0;
+      color: #1b1c1e; }
+  .skill-card__list {
+    display: flex;
+    flex-direction: column;
+    gap: 10px; }
+
+.skill-line {
+  display: flex;
+  gap: 14px;
+  padding: 12px 0;
+  align-items: flex-start;
+  border-bottom: 1px solid #edf0f5; }
+  .skill-line:last-child {
+    border-bottom: none;
+    padding-bottom: 0; }
+  .skill-line__icon {
+    width: 36px;
+    height: 36px;
+    border-radius: 9px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #2f80ed, #56ccf2);
+    color: #fff;
+    font-size: 16px;
+    flex-shrink: 0;
+    box-shadow: 0 6px 14px rgba(47, 128, 237, 0.25); }
+  .skill-line__body h6 {
+    margin: 0 0 8px;
+    color: #1e2430;
+    letter-spacing: 0.2px;
+    font-weight: 600; }
+
+.skill-chip-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px; }
+
+.skill-chip {
+  display: inline-flex;
+  align-items: center;
+  padding: 6px 12px;
+  border-radius: 40px;
+  background: #ffffff;
+  color: #1e2430;
+  font-size: 12px;
+  letter-spacing: 0.3px;
+  border: 1px solid #dbe2ec;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease; }
+  .skill-chip:hover {
+    background: #f1f5fb;
+    border-color: #cfd6e0;
+    color: #0f172a; }
+
+@media (max-width: 767px) {
+  .skill-card {
+    padding: 28px 22px; }
+  .skill-card__header {
+    flex-direction: column;
+    align-items: flex-start; }
+  .skill-line {
+    align-items: flex-start; } }
+
 .skillbar {
   position: relative;
   display: block;

--- a/index.html
+++ b/index.html
@@ -146,53 +146,93 @@
 
 					<br>
 					<br>
-					<!-- skill-section -->
-							<div id="skills" class="active-section">
-	<div class="section-block skill-section">
-		<div class="row">
-			<div class="col-md-6">
-				<div class="skill-content">
-					<h4 class="title">Skills</h4>
+                                        <!-- skill-section -->
+                                                        <div id="skills" class="active-section">
+        <div class="section-block skill-section">
+                <div class="row">
+                        <div class="col-md-12">
+                                <div class="skill-card">
+                                        <div class="skill-card__header">
+                                                <h4 class="title">Skills</h4>
+                                        </div>
+                                        <div class="skill-card__list">
+                                                <div class="skill-line">
+                                                        <div class="skill-line__icon"><i class="fa fa-code"></i></div>
+                                                        <div class="skill-line__body">
+                                                                <h6>Core Languages &amp; Frameworks</h6>
+                                                                <div class="skill-chip-row">
+                                                                        <span class="skill-chip">C#</span>
+                                                                        <span class="skill-chip">.NET Core</span>
+                                                                        <span class="skill-chip">.NET MAUI</span>
+                                                                        <span class="skill-chip">Xamarin</span>
+                                                                        <span class="skill-chip">Blazor</span>
+                                                                        <span class="skill-chip">Razor</span>
+                                                                        <span class="skill-chip">MVVM</span>
+                                                                </div>
+                                                        </div>
+                                                </div>
 
-					<h6>Android Studio</h6>
-					<div class="skillbar clearfix " data-percent="90%">
-						<div class="skillbar-bar" style="width: 10%;"></div>
-						<div class="skill-bar-percent">90%</div>
-					</div> <!-- End Skill Bar -->
+                                                <div class="skill-line">
+                                                        <div class="skill-line__icon"><i class="fa fa-mobile"></i></div>
+                                                        <div class="skill-line__body">
+                                                                <h6>Mobile Development</h6>
+                                                                <div class="skill-chip-row">
+                                                                        <span class="skill-chip">Android</span>
+                                                                        <span class="skill-chip">iOS</span>
+                                                                        <span class="skill-chip">Cross-platform</span>
+                                                                        <span class="skill-chip">Xamarin</span>
+                                                                        <span class="skill-chip">.NET MAUI</span>
+                                                                </div>
+                                                        </div>
+                                                </div>
 
-					<h6>Visual Studio</h6>
-					<div class="skillbar clearfix " data-percent="90%">
-						<div class="skillbar-bar" style="width: 50%;"></div>
-						<div class="skill-bar-percent">90%</div>
-					</div> <!-- End Skill Bar -->
+                                                <div class="skill-line">
+                                                        <div class="skill-line__icon"><i class="fa fa-server"></i></div>
+                                                        <div class="skill-line__body">
+                                                                <h6>Backend &amp; APIs</h6>
+                                                                <div class="skill-chip-row">
+                                                                        <span class="skill-chip">RESTful APIs</span>
+                                                                        <span class="skill-chip">Entity Framework</span>
+                                                                        <span class="skill-chip">Firebase</span>
+                                                                        <span class="skill-chip">OpenAPI Documentation</span>
+                                                                </div>
+                                                        </div>
+                                                </div>
 
-					
+                                                <div class="skill-line">
+                                                        <div class="skill-line__icon"><i class="fa fa-lock"></i></div>
+                                                        <div class="skill-line__body">
+                                                                <h6>DevOps &amp; Security</h6>
+                                                                <div class="skill-chip-row">
+                                                                        <span class="skill-chip">GitLab</span>
+                                                                        <span class="skill-chip">CI/CD</span>
+                                                                        <span class="skill-chip">Automated Pipelines</span>
+                                                                        <span class="skill-chip">Keycloak</span>
+                                                                        <span class="skill-chip">OAuth2</span>
+                                                                        <span class="skill-chip">OIDC</span>
+                                                                </div>
+                                                        </div>
+                                                </div>
 
-					<h6>Pycharm</h6>
-					<div class="skillbar clearfix " data-percent="75%">
-						<div class="skillbar-bar" style="width: 50%;"></div>
-						<div class="skill-bar-percent">75%</div>
-					</div> <!-- End Skill Bar -->
-
-					<h6>Unity</h6>
-					<div class="skillbar clearfix " data-percent="70%">
-						<div class="skillbar-bar" style="width: 30%;"></div>
-						<div class="skill-bar-percent">70%</div>
-					</div> <!-- End Skill Bar -->
-
-					<h6>Photoshop</h6>
-					<div class="skillbar clearfix " data-percent="75%">
-						<div class="skillbar-bar" style="width: 35%;"></div>
-						<div class="skill-bar-percent">75%</div>
-					</div> <!-- End Skill Bar -->
-				</div>
-			</div>
-			<div class="col-md-6">
-				<img class="img-responsive" src="https://i.imgur.com/ASzCBFJ.png" alt="">
-			</div>
-		</div>
-	</div>
-	</div>
+                                                <div class="skill-line">
+                                                        <div class="skill-line__icon"><i class="fa fa-database"></i></div>
+                                                        <div class="skill-line__body">
+                                                                <h6>Databases &amp; Tools</h6>
+                                                                <div class="skill-chip-row">
+                                                                        <span class="skill-chip">MySQL</span>
+                                                                        <span class="skill-chip">PostgreSQL</span>
+                                                                        <span class="skill-chip">Agile</span>
+                                                                        <span class="skill-chip">Scrum</span>
+                                                                        <span class="skill-chip">Jira</span>
+                                                                </div>
+                                                        </div>
+                                                </div>
+                                        </div>
+                                </div>
+                        </div>
+                </div>
+        </div>
+        </div>
 					<br>
 					<br>
 


### PR DESCRIPTION
## Summary
- stack each skill category on its own line within the skills card for cleaner alignment
- refresh styling to remove individual category cards while keeping consistent iconography and chips
- capture updated skills section screenshot for visual verification

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692ee444f6108325bec1ab1d0efba56d)